### PR TITLE
feat: Add useCounter hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as useToggle } from './useToggle';
+export { default as useCounter } from './useCounter';

--- a/src/useCounter/__tests__/index.test.ts
+++ b/src/useCounter/__tests__/index.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import useCounter from '../index';
+
+describe('useCounter', () => {
+  it('should initialize with default initial value 0', () => {
+    const { result } = renderHook(() => useCounter());
+    expect(result.current.count).toBe(0);
+  });
+
+  it('should initialize with a given initial value', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 5 }));
+    expect(result.current.count).toBe(5);
+  });
+
+  it('should increment the count', () => {
+    const { result } = renderHook(() => useCounter());
+    act(() => {
+      result.current.increment();
+    });
+    expect(result.current.count).toBe(1);
+  });
+
+  it('should decrement the count', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 5 }));
+    act(() => {
+      result.current.decrement();
+    });
+    expect(result.current.count).toBe(4);
+  });
+
+  it('should reset the count to the initial value', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 5 }));
+    act(() => {
+      result.current.increment();
+      result.current.increment();
+    });
+    expect(result.current.count).toBe(7);
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.count).toBe(5);
+  });
+
+  it('should reset the count to the default initial value if none provided', () => {
+    const { result } = renderHook(() => useCounter());
+    act(() => {
+      result.current.increment();
+      result.current.increment();
+    });
+    expect(result.current.count).toBe(2);
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.count).toBe(0);
+  });
+
+  it('should set the count to a specific value', () => {
+    const { result } = renderHook(() => useCounter());
+    act(() => {
+      result.current.setValue(10);
+    });
+    expect(result.current.count).toBe(10);
+  });
+});

--- a/src/useCounter/index.ts
+++ b/src/useCounter/index.ts
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+interface UseCounterOptions {
+  initialValue?: number;
+}
+
+interface UseCounterReturn {
+  count: number;
+  increment: () => void;
+  decrement: () => void;
+  reset: () => void;
+  setValue: (value: number) => void;
+}
+
+const useCounter = (options?: UseCounterOptions): UseCounterReturn => {
+  const { initialValue = 0 } = options || {};
+  const [count, setCount] = useState(initialValue);
+
+  const increment = () => setCount(prevCount => prevCount + 1);
+  const decrement = () => setCount(prevCount => prevCount - 1);
+  const reset = () => setCount(initialValue);
+  const setValue = (value: number) => setCount(value);
+
+  return {
+    count,
+    increment,
+    decrement,
+    reset,
+    setValue,
+  };
+};
+
+export default useCounter;


### PR DESCRIPTION
This commit introduces a new custom React hook `useCounter`.

The `useCounter` hook provides functionality to manage a counter's state. It includes the following features:
- Initialization with an optional `initialValue` (defaults to 0).
- `increment` function: Increases the count by 1.
- `decrement` function: Decreases the count by 1.
- `reset` function: Resets the count to its initial value.
- `setValue` function: Sets the count to a specific value.

Unit tests have been added for the `useCounter` hook, covering all its functionalities. The hook is also exported from the main library entry point.